### PR TITLE
Support http stream transport type

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,24 @@ import { FastMCP } from "fastmcp";
 import { z } from "zod";
 import { readAllMarkdownFromDirectories } from "./utils/index.js";
 
+type ServerTransportType = "stdio" | "stream";
+
+function assertTransportType(
+  transportType: string
+): transportType is ServerTransportType {
+  return transportType === "stdio" || transportType === "stream";
+}
 async function main() {
+  // Grab the transport type from the command line
+  const transportType = process.argv[2] ?? "stdio";
+
+  // Make sure the transport type is allowed
+  if (!assertTransportType(transportType)) {
+    throw Error(
+      `Invalid transport type: "${transportType}". Allowed: 'stdio' (default) or 'stream'.`
+    );
+  }
+
   /**
    * Create a new FastMCP server
    */
@@ -127,13 +144,30 @@ async function main() {
    * Start the server
    */
   try {
-    await server.start({
-      transportType: "stdio",
-    });
+    if (transportType === "stdio") {
+      server.start({ transportType });
+    } else if (transportType === "stream") {
+      server.start({
+        transportType: "httpStream",
+        httpStream: {
+          endpoint: "/",
+          port: 8080,
+        },
+      });
+    }
+    console.info(
+      `Aptos Build MCP started with transport type: ${transportType}`
+    );
   } catch (error) {
     console.error("Error starting server:", error);
     process.exit(1);
   }
+
+  // Handle process termination gracefully
+  process.on("SIGINT", () => {
+    console.info("Shutting down server...");
+    process.exit(0);
+  });
 }
 
 main();


### PR DESCRIPTION
Support for future option to serve the MCP through `http` protocol.

We still use the default `stdio` protocol, but that set up will let us run the MCP on a live server/loveable