### PR TITLE
Fixes #32

### DIFF
--- a/integration_guides/claude_code.md
+++ b/integration_guides/claude_code.md
@@ -6,40 +6,61 @@
 npm install -g @anthropic-ai/claude-code
 ```
 
-2. Locate where Claude Code stores its configuration, usually on Mac it is at `~/.claude.json`
-3. Edit the `mcpServers` object in the `json` file with
+2. Obtain your `APTOS_BOT_KEY`:
+   - Visit the [Aptos Developer Portal](https://aptos.dev) and log in with your account
+   - Navigate to the API Keys section and create a new key
+   - Copy the generated key for use in the next step
 
-```json
-{
-  "mcpServers": {
-    "aptos-mcp": {
-      "command": "npx",
-      "args": ["-y", "@aptos-labs/aptos-mcp"],
-      "type": "stdio",
-      "env": {
-        "APTOS_BOT_KEY": "<bot_api_key>"
-      }
-    }
-  }
-}
-```
-
-4.  Make sure to update the `APTOS_BOT_KEY` with the key you generated in the previous step.
-
-5.  Navigate to your project
+3. Navigate to your project
 
 ```bash
 cd your-awesome-project
 ```
 
-6. In a new terminal window type:
+4. Add the Aptos MCP server to your project using the Claude CLI:
+
+```bash
+claude mcp add -s local aptos-mcp npx -e APTOS_BOT_KEY=<your_bot_api_key> -- -y @aptos-labs/aptos-mcp
+```
+
+Replace `<your_bot_api_key>` with the key you generated in step 2.
+
+**Note:** The `-s local` flag adds the MCP server to your project's local configuration. You can also use:
+- `-s user` to add it globally for all projects
+- `-s project` to add it to the project's shared configuration (if you want to commit it to version control)
+
+5. Verify the MCP server was added successfully:
+
+```bash
+claude mcp list
+```
+
+You should see `aptos-mcp` in the list of configured servers.
+
+6. Start Claude Code:
 
 ```bash
 claude
 ```
 
-7. Prompt the agent with `what aptos mcp version are you using?` to verify the connection. The agent should replay with something like:
+7. Verify the connection by prompting: `what aptos mcp version are you using?`
+
+The agent should reply with something like:
 
 ```text
 I'm using Aptos MCP version 0.0.2.
 ```
+
+## Alternative: Using JSON configuration
+
+If you encounter issues with the CLI approach, you can use the JSON method:
+
+```bash
+claude mcp add-json local '{"aptos-mcp": {"command": "npx", "args": ["-y", "@aptos-labs/aptos-mcp"], "type": "stdio", "env": {"APTOS_BOT_KEY": "<your_bot_api_key>"}}}'
+```
+
+## Troubleshooting
+
+- If Claude doesn't recognize the Aptos MCP tools, ensure you've completely quit and restarted Claude Code after adding the configuration
+- Run `claude mcp list` to verify the server is properly configured
+- Check that your `APTOS_BOT_KEY` is valid and has the necessary permissions

--- a/integration_guides/claude_code.md
+++ b/integration_guides/claude_code.md
@@ -7,7 +7,7 @@ npm install -g @anthropic-ai/claude-code
 ```
 
 2. Obtain your `APTOS_BOT_KEY`:
-   - Visit the [Aptos Developer Portal](https://aptos.dev) and log in with your account
+   - Visit the [Aptos Developer Portal](https://build.aptoslabs.com/) and log in with your account
    - Navigate to the API Keys section and create a new key
    - Copy the generated key for use in the next step
 

--- a/integration_guides/claude_code.md
+++ b/integration_guides/claude_code.md
@@ -6,10 +6,7 @@
 npm install -g @anthropic-ai/claude-code
 ```
 
-2. Obtain your `APTOS_BOT_KEY`:
-   - Visit the [Aptos Developer Portal](https://build.aptoslabs.com/) and log in with your account
-   - Navigate to the API Keys section and create a new key
-   - Copy the generated key for use in the next step
+2. Obtain your `APTOS_BOT_KEY` by following the instructions [here](https://github.com/aptos-labs/aptos-npm-mcp?tab=readme-ov-file#generate-a-build-bot-api-key).
 
 3. Navigate to your project
 


### PR DESCRIPTION
## Description
Updates Claude Code setup instructions to use CLI commands instead of manual JSON editing.

Fixes #32 

## Changes
- Replaced manual `~/.claude.json` editing with `claude mcp add` CLI command
- Added step to obtain API key before it's needed
- Added verification step with `claude mcp list`
- Added JSON alternative as fallback
- Added troubleshooting section
- Fixed typo (replay → reply)

## Testing
Tested the CLI command on macOS with Claude Code v1.0.69