### PR TITLE
feat: rename Aptos Build to Geomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ## Prerequisite
 
 - [node and npm](https://nodejs.org/en) (npm ≥ 5.2.0)
-- Build Bot Api Key
+- Geomi Bot Api Key
 
-### Generate a `Build Bot Api Key`
+### Generate a `Geomi Bot Api Key`
 
-To be able to make [Aptos Build](https://build.aptoslabs.com/) actions like managing api keys, etc. Follow those instruction to generate a new Bot Api Key to use with the MCP
+To be able to make [Geomi](https://geomi.dev/) actions like managing api keys, etc. Follow those instruction to generate a new Bot Api Key to use with the MCP
 
-1. Go to [https://build.aptoslabs.com/](https://build.aptoslabs.com/)
+1. Go to [https://geomi.dev/](https://geomi.dev/)
 2. Click on your name in the bottom left corner
 3. Click on "Bot Keys"
 4. Click on the "Create Bot Key" button

--- a/integration_guides/claude_code.md
+++ b/integration_guides/claude_code.md
@@ -6,7 +6,7 @@
 npm install -g @anthropic-ai/claude-code
 ```
 
-2. Obtain your `APTOS_BOT_KEY` by following the instructions [here](https://github.com/aptos-labs/aptos-npm-mcp?tab=readme-ov-file#generate-a-build-bot-api-key).
+2. Obtain your `APTOS_BOT_KEY` by following the instructions [here](https://github.com/aptos-labs/aptos-npm-mcp?tab=readme-ov-file#generate-a-geomi-bot-api-key).
 
 3. Navigate to your project
 

--- a/integration_guides/user_guide.md
+++ b/integration_guides/user_guide.md
@@ -24,13 +24,13 @@ Users should create proposals, vote once per wallet, view real-time results.
 Include a wallet integration for Aptos testnet."
 ```
 
-## Aptos Build Queries - Be Precise
+## Geomi Queries - Be Precise
 
 **Good Examples:**
 
-- "Get me all of my applications on Aptos Build"
+- "Get me all of my applications on Geomi"
 - "Create a new Full node API key resource named 'MyDApp-Production'"
-- "List all active API keys for my Build account"
+- "List all active API keys for my Geomi account"
 
 ## Perfect Prompt Template
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-  "name": "aptos-mcp-server",
-  "version": "0.0.1",
+  "name": "@aptos-labs/aptos-mcp",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aptos-mcp-server",
-      "version": "0.0.1",
+      "name": "@aptos-labs/aptos-mcp",
+      "version": "0.0.17",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aptos-labs/api-gateway-admin-api-client": "^2.1.0",
-        "aptos-mcp-server": "^0.0.1",
+        "@aptos-labs/api-gateway-admin-api-client": "^4.0.0",
         "dotenv": "^16.6.1",
         "fastmcp": "^1.27.3",
         "zod": "^3.24.4"
@@ -32,9 +31,9 @@
       }
     },
     "node_modules/@aptos-labs/api-gateway-admin-api-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/api-gateway-admin-api-client/-/api-gateway-admin-api-client-2.1.0.tgz",
-      "integrity": "sha512-HbArOFcK83yml49fiI8EmSA3BhNNy9wBtK96AHPqP5nBYrG2lZpNUXCs/aJpSsYAJJ5hTnZ2PPHtsE2PxpRv4g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/api-gateway-admin-api-client/-/api-gateway-admin-api-client-4.0.0.tgz",
+      "integrity": "sha512-XGKaNPWrBiGCqMN9vw9n0GTgteHcASy6Sw3utP90YT/XP1+O7yshTWlK2URBXGU6hwsust57wcmj8AsDEaF9ZA==",
       "dependencies": {
         "@rspc/client": "0.2.0",
         "@rspc/react": "0.2.0"
@@ -1529,21 +1528,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aptos-mcp-server": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/aptos-mcp-server/-/aptos-mcp-server-0.0.1.tgz",
-      "integrity": "sha512-FCNtck+4lFj6QALY7ylNOyNAt1/76/o+lZZ4zqqRQZpsaHonGt2X50Ba6D0gf101z5UrbVEc3CbEJA/2L+wjEA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aptos-labs/api-gateway-admin-api-client": "^2.1.0",
-        "dotenv": "^16.6.1",
-        "fastmcp": "^1.27.3",
-        "zod": "^3.24.4"
-      },
-      "bin": {
-        "aptos-mcp": "dist/server.js"
       }
     },
     "node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "format": "prettier --write . && eslint --fix ."
   },
   "dependencies": {
-    "@aptos-labs/api-gateway-admin-api-client": "^2.1.0",
+    "@aptos-labs/api-gateway-admin-api-client": "^4.0.0",
     "dotenv": "^16.6.1",
     "fastmcp": "^1.27.3",
     "zod": "^3.24.4"

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ const GA_CLIENT_ID = process.env.GA_CLIENT_ID;
 
 // Aptos MCP configuration
 export const config = {
-  aptos_build: {
+  geomi: {
     adminUrl: "https://admin.api.aptoslabs.com/api/rspc",
     botKey: process.env.APTOS_BOT_KEY,
   },

--- a/src/resources/how_to/how_to_config_a_full_node_api_key_in_a_dapp.md
+++ b/src/resources/how_to/how_to_config_a_full_node_api_key_in_a_dapp.md
@@ -1,6 +1,6 @@
 # How to config a Full Node API Key for general blockchain interactions in an Aptos dapp
 
-Aptos full node api keys are designed as indentifications for authentication and rate limiting purposes. If you do not use an API key, your client will be considered “anonymous” and subject to significantly lower rate limits.
+Aptos full node api keys are designed as indentifications for authentication and rate limiting purposes. If you do not use an API key, your client will be considered "anonymous" and subject to significantly lower rate limits.
 
 The full node api key is used for general blockchain interactions when an applications wants to read data from chain or submit data to chain.
 
@@ -9,7 +9,7 @@ It is structured to enforce user validation steps before applying any modificati
 
 ### 🟩 Step 1: Retrieve & Display Available API Keys
 
-1. Fetch the user's Build Organizations, including:
+1. Fetch the user's Geomi Organizations, including:
 
 - Organizations
 - Applications
@@ -94,6 +94,6 @@ const aptos = new Aptos(
 - ✅ If mismatched, warn the user and ask for confirmation before proceeding.
 
 ### 🟩 Bonus: Documentation References
-[Build API Keys Guide](https://build.aptoslabs.com/docs/start/api-keys)
+[Geomi API Keys Guide](https://geomi.dev/docs/start/api-keys)
 
 ```

--- a/src/resources/how_to/how_to_config_a_gas_station_in_a_dapp.md
+++ b/src/resources/how_to/how_to_config_a_gas_station_in_a_dapp.md
@@ -9,7 +9,7 @@ It is structured to enforce user validation steps before applying any modificati
 
 ### 🟩 Step 1: Retrieve & Display Available GAS STATION API Keys
 
-1. Fetch the user's Build Organizations, including:
+1. Fetch the user's Geomi Organizations, including:
 
 - Organizations
 - Applications
@@ -102,6 +102,6 @@ import { aptosClient } from "../utils/aptosClient"; // this has our network defi
 - ✅ If mismatched, warn the user and ask for confirmation before proceeding.
 
 ### 🟩 Bonus: Documentation References
-[Build Gas Station Guide](https://build.aptoslabs.com/docs/gas-stations)
+[Geomi Gas Station Guide](https://geomi.dev/docs/gas-stations)
 
 ```

--- a/src/resources/how_to/how_to_handle_rate_limit_in_a_dapp.md
+++ b/src/resources/how_to/how_to_handle_rate_limit_in_a_dapp.md
@@ -64,7 +64,7 @@ Ensure the configured API key network matches the network your dapp is using:
    - Common networks: `Network.MAINNET`, `Network.TESTNET`, `Network.DEVNET`
 
 2. **Verify API key network**:
-   - Check your Build console to see which network the API key was created for
+   - Check your Geomi console to see which network the API key was created for
    - API keys are network-specific and cannot be used across different networks
 
 ### 2.2 If Networks Don't Match
@@ -80,7 +80,7 @@ Ensure the configured API key network matches the network your dapp is using:
 
 If you have a properly configured API key but still experience rate limits:
 
-1. **Check your API key's rate limit settings** in the Aptos Build console:
+1. **Check your API key's rate limit settings** in the Geomi console:
 
    - Look for the `httpRateLimitPerIp` property
    - This determines how many requests per second your application can make
@@ -93,12 +93,12 @@ If you have a properly configured API key but still experience rate limits:
 
 If the current `httpRateLimitPerIp` is too low:
 
-1. **Navigate to your Aptos Build console**
+1. **Navigate to your Geomi console**
 2. **Select your API key**
 3. **Increase the `httpRateLimitPerIp` value** to a more appropriate level
 4. **Save the changes**
 
-⚠️ **Note**: Higher rate limits may incur additional costs depending on your Build plan.
+⚠️ **Note**: Higher rate limits may incur additional costs depending on your Geomi plan.
 
 ## 🟩 Step 4: Implement Rate Limit Error Handling in Code
 
@@ -162,5 +162,5 @@ Implement monitoring to track:
 
 ## 🟩 Additional Resources
 
-- [Aptos Build API Keys Guide](https://build.aptoslabs.com/docs/start/api-keys)
+- [Geomi API Keys Guide](https://geomi.dev/docs/start/api-keys)
 - [How to config a Full Node API Key in a dapp](./how_to_config_a_full_node_api_key_in_a_dapp.md)

--- a/src/resources/how_to/how_to_integrate_no_code_indexer.md
+++ b/src/resources/how_to/how_to_integrate_no_code_indexer.md
@@ -1,17 +1,17 @@
-# How to Set Up No-Code Indexing with Aptos Build
+# How to Set Up No-Code Indexing with Geomi
 
-No-Code Indexing allows you to create real-time blockchain data indexers without writing custom indexing logic or managing/building infrastructure. Use it to query smart contract events in real-time for your dApp frontend.
+No-Code Indexing allows you to create real-time blockchain data indexers without writing custom indexing logic or managing/building infrastructure. Use it to query smart contract events in real-time for your dApp frontend. Geomi is the essential toolkit for Aptos developers.
 
 ## Prerequisites
 
 - Deployed Move smart contract with events on Testnet or Mainnet
 - Contract address and event structures
-- Aptos Build account
+- Geomi account
 
-## Project Setup in Aptos Build
+## Project Setup in Geomi
 
-1. **Create processor in Aptos Build**:
-   - Go to [Aptos Build](https://build.aptoslabs.com/) and sign in
+1. **Create processor in Geomi**:
+   - Go to [Geomi](https://geomi.dev/) and sign in
    - Click "Create New Project" → "Processor"
    - Name your project (3-32 characters, lowercase, numbers, `_` or `-`)
 
@@ -55,7 +55,7 @@ query {
 ```
 
 4. **Get API credentials**:
-   - Return to Aptos Build → your project → API Keys
+   - Return to Geomi → your project → API Keys
    - Copy API key (starts with `aptoslabs_...`)
    - Note processor ID from API URL
 
@@ -262,3 +262,4 @@ curl -X POST https://api.testnet.aptoslabs.com/nocode/v1/api/YOUR_PROCESSOR_ID/v
    - **GraphQL errors**: Check table and column names match exactly
 
 Replace `your_table_name` with your actual table name and adjust column names to match your event structure.
+

--- a/src/resources/management/how_to_create_and_manage_keys.md
+++ b/src/resources/management/how_to_create_and_manage_keys.md
@@ -1,10 +1,10 @@
 # How to Create and Manage Keys
 
-This guide provides an overview of the different types of API keys available in Aptos Build and where to create each type. Use this as a central reference point for understanding key management across your Aptos projects.
+This guide provides an overview of the different types of API keys available in Geomi and where to create each type. Geomi is the essential toolkit for Aptos developers. Use this as a central reference point for understanding key management across your Aptos projects.
 
 ## Overview of Key Types
 
-Aptos Build supports three main types of API keys, each serving different purposes:
+Geomi supports three main types of API keys, each serving different purposes:
 
 ### Full Node API Keys
 
@@ -28,7 +28,7 @@ Auto-generated keys for accessing indexed blockchain data through the No-Code In
 
 ### Full Node API Keys
 
-1. Navigate to the [Aptos Build dashboard](https://build.aptos.dev)
+1. Navigate to the [Geomi dashboard](https://geomi.dev)
 2. Go to **API Keys** section
 3. Click **Create New API Key**
 4. Configure your key settings and network preferences
@@ -38,7 +38,7 @@ Auto-generated keys for accessing indexed blockchain data through the No-Code In
 
 Gas Station keys are automatically generated when you create a Gas Station project:
 
-1. Navigate to **Gas Station** in the Aptos Build dashboard
+1. Navigate to **Gas Station** in the Geomi dashboard
 2. Create a new Gas Station project
 3. Your API key will be automatically generated and displayed
 4. Copy the key for use in your application
@@ -47,7 +47,7 @@ Gas Station keys are automatically generated when you create a Gas Station proje
 
 Indexer keys are automatically generated when you create a Processor project:
 
-1. Navigate to **No-Code Indexer** in the Aptos Build dashboard
+1. Navigate to **No-Code Indexer** in the Geomi dashboard
 2. Create a new Processor project
 3. Your indexer API key will be automatically generated
 4. Use this key to access your indexed data
@@ -58,11 +58,11 @@ For detailed implementation instructions, see these specific guides:
 
 - **[Full Node API Key Configuration](../how_to/how_to_config_a_full_node_api_key_in_a_dapp.md)**: Detailed guide on creating and managing Full Node API keys
 - **[Gas Station Integration](../how_to/how_to_integrate_gas_station.md)**: Complete guide on integrating Gas Station for gasless transactions
-- **[No-Code Indexer Integration](../how_to/how_to_integrate_no_code_indexer_build.md)**: Step-by-step guide for setting up and using the No-Code Indexer
+- **[No-Code Indexer Integration](../how_to/how_to_integrate_no_code_indexer.md)**: Step-by-step guide for setting up and using the No-Code Indexer
 
 ## Security Best Practices
 
 - Store all API keys in environment variables, never in source code
 - Use different keys for development, staging, and production environments
 - Regularly rotate your API keys for enhanced security
-- Monitor key usage through the Aptos Build dashboard
+- Monitor key usage through the Geomi dashboard

--- a/src/services/GasStation.ts
+++ b/src/services/GasStation.ts
@@ -7,10 +7,10 @@ export class GasStation {
   private readonly context: Context<any>;
 
   constructor(context: Context<any>, network: "testnet" | "mainnet") {
-    if (!config.aptos_build.botKey) {
+    if (!config.geomi.botKey) {
       throw new Error(
         `APTOS_BOT_KEY is not set. To generate a Bot Key: 
-        1. Go to [https://build.aptoslabs.com/](https://build.aptoslabs.com/)
+        1. Go to [https://geomi.dev/](https://geomi.dev/)
         2. Click on your name in the bottom left corner
         3. Click on "Bot Keys"
         4. Click on the "Create Bot Key" button
@@ -22,7 +22,7 @@ export class GasStation {
         ? config.gas_station.testnetUrl
         : config.gas_station.mainnetUrl;
     this.headers = {
-      Authorization: `Bearer ${config.aptos_build.botKey}`,
+      Authorization: `Bearer ${config.geomi.botKey}`,
       "x-is-aptos-bot": "true",
       "Content-Type": "application/json",
     };

--- a/src/services/Geomi.ts
+++ b/src/services/Geomi.ts
@@ -12,25 +12,25 @@ import {
 import { config } from "../config.js";
 import { Context } from "fastmcp";
 
-export class AptosBuild {
+export class Geomi {
   protected readonly headers: Record<string, string>;
   private readonly adminUrl: string;
   private readonly context: Context<any>;
 
   constructor(context: Context<any>) {
-    if (!config.aptos_build.botKey) {
+    if (!config.geomi.botKey) {
       throw new Error(
         `APTOS_BOT_KEY is not set. To generate a Bot Key: 
-        1. Go to [https://build.aptoslabs.com/](https://build.aptoslabs.com/)
+        1. Go to [https://geomi.dev/](https://geomi.dev/)
         2. Click on your name in the bottom left corner
         3. Click on "Bot Keys"
         4. Click on the "Create Bot Key" button
         5. Copy the Bot Key and paste it into the MCP configuration file as an env arg: APTOS_BOT_KEY=<your-bot-key>`
       );
     }
-    this.adminUrl = config.aptos_build.adminUrl;
+    this.adminUrl = config.geomi.adminUrl;
     this.headers = {
-      Authorization: `Bearer ${config.aptos_build.botKey}`,
+      Authorization: `Bearer ${config.geomi.botKey}`,
       "x-is-aptos-bot": "true",
     };
     this.context = context;
@@ -398,3 +398,4 @@ export class AptosBuild {
     };
   };
 }
+

--- a/src/tools/geomi/apiKey.ts
+++ b/src/tools/geomi/apiKey.ts
@@ -1,27 +1,28 @@
 import { Tool } from "fastmcp";
 
-import { AptosBuild } from "../../services/AptosBuild.js";
+import { Geomi } from "../../services/Geomi.js";
 import { recordTelemetry } from "../../utils/telemetry.js";
 import {
   CreateApiKeyToolScheme,
   UpdateApiKeyToolScheme,
   DeleteApiKeyToolScheme,
+  toApiFrontendArgs,
 } from "../types/organization.js";
 
 /**
- * Tool to create an API Key for your Aptos Build Organization.
+ * Tool to create an API Key for your Geomi Organization.
  */
 export const createApiKeyTool: Tool<undefined, typeof CreateApiKeyToolScheme> =
   {
-    description: `Create a new API Key for your Aptos Build Organization. Api Keys are secret keys so it is important to keep them safe and secure. 
-      This tool can be used to create an Api Key (aka full node api key) for an Api resource application.`,
+    description: `Create a new API Key for your Geomi Organization. Geomi is the essential toolkit for Aptos developers. Api Keys are secret keys so it is important to keep them safe and secure. 
+      This tool can be used to create an Api Key (aka full node api key) for an Api resource application to interact with the Aptos blockchain.`,
     execute: async (args, context) => {
       try {
         await recordTelemetry({ action: "create_api_key" }, context);
-        const aptosBuild = new AptosBuild(context);
-        const apiKey = await aptosBuild.createApiKey({
+        const geomi = new Geomi(context);
+        const apiKey = await geomi.createApiKey({
           application_id: args.application_id,
-          frontend_args: args.frontend_args ?? null,
+          frontend_args: toApiFrontendArgs(args.frontend_args),
           name: args.name,
           organization_id: args.organization_id,
           project_id: args.project_id,
@@ -31,27 +32,27 @@ export const createApiKeyTool: Tool<undefined, typeof CreateApiKeyToolScheme> =
         return `❌ Failed to create api key: ${error}`;
       }
     },
-    name: "create_aptos_build_api_key",
+    name: "create_geomi_api_key",
     parameters: CreateApiKeyToolScheme,
   };
 
 /**
- * Tool to update an API Key for your Aptos Build Organization.
+ * Tool to update an API Key for your Geomi Organization.
  */
 export const updateApiKeyTool: Tool<undefined, typeof UpdateApiKeyToolScheme> =
   {
-    description: "Update an API Key for your Aptos Build Organization.",
+    description: "Update an API Key for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
     execute: async (args, context) => {
       try {
         await recordTelemetry({ action: "update_api_key" }, context);
-        const aptosBuild = new AptosBuild(context);
+        const geomi = new Geomi(context);
         context.log.info(
           `Updating api key: ${JSON.stringify(args.frontend_args)}`
         );
-        const apiKey = await aptosBuild.updateApiKey({
+        const apiKey = await geomi.updateApiKey({
           application_id: args.application_id,
           current_api_key_name: args.current_api_key_name,
-          frontend_args: args.frontend_args ?? null,
+          frontend_args: toApiFrontendArgs(args.frontend_args),
           new_api_key_name: args.new_api_key_name ?? args.current_api_key_name,
           organization_id: args.organization_id,
           project_id: args.project_id,
@@ -61,21 +62,21 @@ export const updateApiKeyTool: Tool<undefined, typeof UpdateApiKeyToolScheme> =
         return `❌ Failed to update api key: ${error}`;
       }
     },
-    name: "update_aptos_build_api_key",
+    name: "update_geomi_api_key",
     parameters: UpdateApiKeyToolScheme,
   };
 
 /**
- * Tool to delete an API Key for your Aptos Build Organization.
+ * Tool to delete an API Key for your Geomi Organization.
  */
 export const deleteApiKeyTool: Tool<undefined, typeof DeleteApiKeyToolScheme> =
   {
-    description: "Delete an API Key for your Aptos Build Organization.",
+    description: "Delete an API Key for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
     execute: async (args, context) => {
       try {
         await recordTelemetry({ action: "delete_api_key" }, context);
-        const aptosBuild = new AptosBuild(context);
-        const apiKey = await aptosBuild.deleteApiKey({
+        const geomi = new Geomi(context);
+        const apiKey = await geomi.deleteApiKey({
           application_id: args.application_id,
           api_key_name: args.api_key_name,
           organization_id: args.organization_id,
@@ -86,6 +87,7 @@ export const deleteApiKeyTool: Tool<undefined, typeof DeleteApiKeyToolScheme> =
         return `❌ Failed to delete api key: ${error}`;
       }
     },
-    name: "delete_aptos_build_api_key",
+    name: "delete_geomi_api_key",
     parameters: DeleteApiKeyToolScheme,
   };
+

--- a/src/tools/geomi/applications.ts
+++ b/src/tools/geomi/applications.ts
@@ -1,7 +1,7 @@
 import { Tool } from "fastmcp";
 import { z } from "zod";
 
-import { AptosBuild } from "../../services/AptosBuild.js";
+import { Geomi } from "../../services/Geomi.js";
 import { recordTelemetry } from "../../utils/telemetry.js";
 import {
   CreateApiResourceApplicationToolScheme,
@@ -9,50 +9,51 @@ import {
   DeleteApplicationToolScheme,
   getApplicationsToolScheme,
   UpdateApplicationNameToolScheme,
+  toApiFrontendArgs,
 } from "../types/organization.js";
 import { GasStation } from "../../services/GasStation.js";
 
 /**
- * Tool to get all applications for your Aptos Build Organization.
+ * Tool to get all applications for your Geomi Organization.
  */
 export const getApplicationsTool: Tool<
   undefined,
   typeof getApplicationsToolScheme
 > = {
-  description: `Get your Aptos Build Organizations with their projects and applications and the API Keys. Api Keys are secret keys so it is important to keep them safe and secure.
+  description: `Get your Geomi Organizations with their projects and applications and the API Keys. Geomi is the essential toolkit for Aptos developers. Api Keys are secret keys so it is important to keep them safe and secure.
     To get the full node api keys, you need to get the Applications with a serviceType of "Api".
     To get the gas station api keys, you need to get the Applications with a serviceType of "Gs".`,
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "get_applications" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const organizations = await aptosBuild.getApplications();
+      const geomi = new Geomi(context);
+      const organizations = await geomi.getApplications();
       return JSON.stringify(organizations);
     } catch (error) {
       return `❌ Failed to get organizations: ${error}`;
     }
   },
-  name: "get_aptos_build_applications",
+  name: "get_geomi_applications",
   parameters: z.object({}),
 };
 
 /**
- * Tool to create a new Full Node API Resource application for your Aptos Build Organization.
+ * Tool to create a new Full Node API Resource application for your Geomi Organization.
  */
 export const createApiResourceApplicationTool: Tool<
   undefined,
   typeof CreateApiResourceApplicationToolScheme
 > = {
   description:
-    "Create a new Application for your Aptos Build Organization. This tool can be used to create an API resource application to then create api keys for general blockchain interactions.",
+    "Create a new Application for your Geomi Organization. Geomi is the essential toolkit for Aptos developers. This tool can be used to create an API resource application to then create api keys for general Aptos blockchain interactions.",
   execute: async (args, context) => {
     try {
       await recordTelemetry(
         { action: "create_api_resource_application" },
         context
       );
-      const aptosBuild = new AptosBuild(context);
-      const application = await aptosBuild.createApplication({
+      const geomi = new Geomi(context);
+      const application = await geomi.createApplication({
         args: {
           description: args.description ?? null,
           name: args.name,
@@ -67,21 +68,21 @@ export const createApiResourceApplicationTool: Tool<
       return `❌ Failed to create application: ${error}`;
     }
   },
-  name: "create_aptos_build_api_resource_application",
+  name: "create_geomi_api_resource_application",
   parameters: CreateApiResourceApplicationToolScheme,
 };
 
 /**
- * Tool to create a new Full Node API Resource application for your Aptos Build Organization.
+ * Tool to create a new Gas Station application for your Geomi Organization.
  */
 export const createGasStationApplicationTool: Tool<
   undefined,
   typeof CreateGasStationApplicationToolScheme
 > = {
   description:
-    "Create a new Application for your Aptos Build Organization. This tool can be used to create an Gas Station application. Gas Station is a service that allows you to create gas stations for your Aptos dApps.",
+    "Create a new Application for your Geomi Organization. Geomi is the essential toolkit for Aptos developers. This tool can be used to create a Gas Station application. Gas Station is a service that allows you to sponsor gas fees for your Aptos dApps users.",
   execute: async (args, context) => {
-    const aptosBuild = new AptosBuild(context);
+    const geomi = new Geomi(context);
     let applicationId: string | null = null;
     try {
       await recordTelemetry(
@@ -89,7 +90,7 @@ export const createGasStationApplicationTool: Tool<
         context
       );
       // Create the application
-      const application = await aptosBuild.createApplication({
+      const application = await geomi.createApplication({
         args: {
           description: args.description ?? null,
           name: args.name,
@@ -103,11 +104,11 @@ export const createGasStationApplicationTool: Tool<
       applicationId = application.id;
 
       // Create the API key for the Gs application
-      const apiKey = await aptosBuild.createApiKey({
+      const apiKey = await geomi.createApiKey({
         organization_id: args.organization_id,
         project_id: args.project_id,
         application_id: application.id,
-        frontend_args: args.frontend_args ?? null,
+        frontend_args: toApiFrontendArgs(args.frontend_args),
         name: args.api_key_name,
       });
 
@@ -137,7 +138,7 @@ export const createGasStationApplicationTool: Tool<
     } catch (error) {
       // Delete the new application if the processor creation fails so that it's not orphaned.
       if (applicationId) {
-        await aptosBuild.deleteApplication({
+        await geomi.deleteApplication({
           application_id: applicationId,
           organization_id: args.organization_id,
           project_id: args.project_id,
@@ -151,18 +152,18 @@ export const createGasStationApplicationTool: Tool<
 };
 
 /**
- * Tool to delete an Application for your Aptos Build Organization.
+ * Tool to delete an Application for your Geomi Organization.
  */
 export const deleteApplicationTool: Tool<
   undefined,
   typeof DeleteApplicationToolScheme
 > = {
-  description: "Delete an Application for your Aptos Build Organization.",
+  description: "Delete an Application for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "delete_application" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const application = await aptosBuild.deleteApplication({
+      const geomi = new Geomi(context);
+      const application = await geomi.deleteApplication({
         application_id: args.application_id,
         organization_id: args.organization_id,
         project_id: args.project_id,
@@ -172,23 +173,23 @@ export const deleteApplicationTool: Tool<
       return `❌ Failed to delete application: ${error}`;
     }
   },
-  name: "delete_aptos_application",
+  name: "delete_geomi_application",
   parameters: DeleteApplicationToolScheme,
 };
 
 /**
- * Tool to update an Application name for your Aptos Build Organization.
+ * Tool to update an Application name for your Geomi Organization.
  */
 export const updateApplicationNameTool: Tool<
   undefined,
   typeof UpdateApplicationNameToolScheme
 > = {
-  description: "Update an Application name for your Aptos Build Organization.",
+  description: "Update an Application name for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "update_application_name" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const application = await aptosBuild.updateApplicationName({
+      const geomi = new Geomi(context);
+      const application = await geomi.updateApplicationName({
         application_id: args.application_id,
         organization_id: args.organization_id,
         project_id: args.project_id,
@@ -199,6 +200,7 @@ export const updateApplicationNameTool: Tool<
       return `❌ Failed to update application name: ${error}`;
     }
   },
-  name: "update_aptos_build_application_name",
+  name: "update_geomi_application_name",
   parameters: UpdateApplicationNameToolScheme,
 };
+

--- a/src/tools/geomi/index.ts
+++ b/src/tools/geomi/index.ts
@@ -22,7 +22,7 @@ import {
   updateProjectTool,
 } from "./projects.js";
 
-export function registerAptosBuildTools(server: FastMCP): void {
+export function registerGeomiTools(server: FastMCP): void {
   // get all user's organizations + projects + applications + api keys
   server.addTool(getApplicationsTool);
   // Create tools
@@ -41,3 +41,4 @@ export function registerAptosBuildTools(server: FastMCP): void {
   server.addTool(deleteProjectTool);
   server.addTool(deleteApiKeyTool);
 }
+

--- a/src/tools/geomi/organization.ts
+++ b/src/tools/geomi/organization.ts
@@ -1,6 +1,6 @@
 import type { Tool } from "fastmcp";
 
-import { AptosBuild } from "../../services/AptosBuild.js";
+import { Geomi } from "../../services/Geomi.js";
 import { recordTelemetry } from "../../utils/telemetry.js";
 import {
   CreateOrganizationToolScheme,
@@ -8,18 +8,18 @@ import {
 } from "../types/organization.js";
 
 /**
- * Tool to create a new Organization for your Aptos Build.
+ * Tool to create a new Organization for your Geomi account.
  */
 export const createOrganizationTool: Tool<
   undefined,
   typeof CreateOrganizationToolScheme
 > = {
-  description: "Create a new Organization for your Aptos Build.",
+  description: "Create a new Organization for your Geomi account. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "create_organization" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const organization = await aptosBuild.createOrganization({
+      const geomi = new Geomi(context);
+      const organization = await geomi.createOrganization({
         name: args.name,
       });
       return JSON.stringify(organization);
@@ -27,23 +27,23 @@ export const createOrganizationTool: Tool<
       return `❌ Failed to create organization: ${error}`;
     }
   },
-  name: "create_aptos_build_organization",
+  name: "create_geomi_organization",
   parameters: CreateOrganizationToolScheme,
 };
 
 /**
- * Tool to update an Organization for your Aptos Build.
+ * Tool to update an Organization for your Geomi account.
  */
 export const updateOrganizationTool: Tool<
   undefined,
   typeof UpdateOrganizationToolScheme
 > = {
-  description: "Update an Organization for your Aptos Build.",
+  description: "Update an Organization for your Geomi account. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "update_organization" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const organization = await aptosBuild.updateOrganization({
+      const geomi = new Geomi(context);
+      const organization = await geomi.updateOrganization({
         name: args.name,
         organization_id: args.organization_id,
       });
@@ -52,6 +52,7 @@ export const updateOrganizationTool: Tool<
       return `❌ Failed to update organization: ${error}`;
     }
   },
-  name: "update_aptos_build_organization",
+  name: "update_geomi_organization",
   parameters: UpdateOrganizationToolScheme,
 };
+

--- a/src/tools/geomi/projects.ts
+++ b/src/tools/geomi/projects.ts
@@ -1,6 +1,6 @@
 import { Tool } from "fastmcp";
 
-import { AptosBuild } from "../../services/AptosBuild.js";
+import { Geomi } from "../../services/Geomi.js";
 import { recordTelemetry } from "../../utils/telemetry.js";
 import {
   CreateProjectToolScheme,
@@ -9,18 +9,18 @@ import {
 } from "../types/organization.js";
 
 /**
- * Tool to create a new Project for your Aptos Build Organization.
+ * Tool to create a new Project for your Geomi Organization.
  */
 export const createProjectTool: Tool<
   undefined,
   typeof CreateProjectToolScheme
 > = {
-  description: "Create a new Project for your Aptos Build Organization.",
+  description: "Create a new Project for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "create_project" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const project = await aptosBuild.createProject({
+      const geomi = new Geomi(context);
+      const project = await geomi.createProject({
         description: args.description,
         organization_id: args.organization_id,
         project_name: args.project_name,
@@ -30,23 +30,23 @@ export const createProjectTool: Tool<
       return `❌ Failed to create project: ${error}`;
     }
   },
-  name: "create_aptos_build_project",
+  name: "create_geomi_project",
   parameters: CreateProjectToolScheme,
 };
 
 /**
- * Tool to update a Project for your Aptos Build Organization.
+ * Tool to update a Project for your Geomi Organization.
  */
 export const updateProjectTool: Tool<
   undefined,
   typeof UpdateProjectToolScheme
 > = {
-  description: "Update a Project for your Aptos Build Organization.",
+  description: "Update a Project for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "update_project" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const project = await aptosBuild.updateProject({
+      const geomi = new Geomi(context);
+      const project = await geomi.updateProject({
         description: args.description ?? "",
         organization_id: args.organization_id,
         project_id: args.project_id,
@@ -57,23 +57,23 @@ export const updateProjectTool: Tool<
       return `❌ Failed to update project: ${error}`;
     }
   },
-  name: "update_aptos_build_project",
+  name: "update_geomi_project",
   parameters: UpdateProjectToolScheme,
 };
 
 /**
- * Tool to delete a Project for your Aptos Build Organization.
+ * Tool to delete a Project for your Geomi Organization.
  */
 export const deleteProjectTool: Tool<
   undefined,
   typeof DeleteProjectToolScheme
 > = {
-  description: "Delete a Project for your Aptos Build Organization.",
+  description: "Delete a Project for your Geomi Organization. Geomi is the essential toolkit for Aptos developers.",
   execute: async (args, context) => {
     try {
       await recordTelemetry({ action: "delete_project" }, context);
-      const aptosBuild = new AptosBuild(context);
-      const response = await aptosBuild.deleteProject({
+      const geomi = new Geomi(context);
+      const response = await geomi.deleteProject({
         organization_id: args.organization_id,
         project_id: args.project_id,
       });
@@ -82,6 +82,7 @@ export const deleteProjectTool: Tool<
       return `❌ Failed to delete project: ${error}`;
     }
   },
-  name: "delete_aptos_build_project",
+  name: "delete_geomi_project",
   parameters: DeleteProjectToolScheme,
 };
+

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { FastMCP } from "fastmcp";
 
-import { registerAptosBuildTools } from "./aptos_build/index.js";
+import { registerGeomiTools } from "./geomi/index.js";
 
 export function registerTools(server: FastMCP): void {
-  registerAptosBuildTools(server);
+  registerGeomiTools(server);
 }

--- a/src/tools/types/organization.ts
+++ b/src/tools/types/organization.ts
@@ -1,4 +1,24 @@
 import { z } from "zod";
+import { CreateApiKeyFrontendArgs } from "@aptos-labs/api-gateway-admin-api-client";
+
+// Helper to convert Zod-validated frontend_args to API type
+type ZodFrontendArgs = z.infer<typeof CreateApiKeyToolScheme>["frontend_args"];
+
+export function toApiFrontendArgs(
+  args: ZodFrontendArgs
+): CreateApiKeyFrontendArgs | null {
+  if (!args) return null;
+  // Type assertion needed because Zod infers string for enum fields,
+  // but the API uses strict union types (HttpLimitScope, Duration, etc.)
+  // The runtime values are compatible - this is just a compile-time type mismatch.
+  return {
+    web_app_urls: args.web_app_urls ?? [],
+    extension_ids: args.extension_ids ?? [],
+    per_ip_limit_rules: args.per_ip_limit_rules ?? [],
+    enforce_origin: args.enforce_origin ?? false,
+    per_ip_stream_limit: args.per_ip_stream_limit ?? null,
+  } as unknown as CreateApiKeyFrontendArgs;
+}
 
 // Get Organizations Scheme
 export const getApplicationsToolScheme = z.object({});
@@ -12,31 +32,54 @@ export const GetProjectsToolScheme = z.object({
     ),
 });
 
+// Http Limit Rule Schema for v4 API
+const HttpLimitRuleKeySchema = z.object({
+  scope: z.string().describe("The scope of the limit rule (e.g., 'PerIp')"),
+  limit_unit: z.string().describe("The unit of the limit (e.g., 'ComputeUnits')"),
+  window: z.string().describe("The time window for the limit (e.g., '5m')"),
+});
+
+const HttpLimitRuleSchema = z.object({
+  key: HttpLimitRuleKeySchema,
+  limit: z.number().describe("The limit value"),
+});
+
 // Create Api Key Scheme
 export const CreateApiKeyToolScheme = z.object({
   application_id: z
     .string()
     .describe("The application id to create the api key for."),
-  frontend_args: z.object({
-    extension_ids: z
-      .array(z.string())
-      .describe(
-        "The extension ids to allow the api key to access. If not provided, all extension ids will be allowed."
-      )
-      .default([]),
-    http_rate_limit_per_ip: z
-      .number()
-      .describe(
-        "The http rate limit per ip. If not provided, the default 2,000,000 Compute Units per 5 minutes rate limit will be used."
-      )
-      .default(2000000),
-    web_app_urls: z
-      .array(z.string())
-      .describe(
-        "The web app urls to allow the api key to access. If not provided, all URLs will be allowed."
-      )
-      .default([]),
-  }),
+  frontend_args: z
+    .object({
+      extension_ids: z
+        .array(z.string())
+        .describe(
+          "The extension ids to allow the api key to access. If not provided, all extension ids will be allowed."
+        )
+        .default([]),
+      web_app_urls: z
+        .array(z.string())
+        .describe(
+          "The web app urls to allow the api key to access. If not provided, all URLs will be allowed."
+        )
+        .default([]),
+      per_ip_limit_rules: z
+        .array(HttpLimitRuleSchema)
+        .describe(
+          "Per-IP rate limit rules. Leave empty for default rate limits."
+        )
+        .default([]),
+      enforce_origin: z
+        .boolean()
+        .describe("Whether to enforce origin checking for requests.")
+        .default(false),
+      per_ip_stream_limit: z
+        .number()
+        .nullable()
+        .describe("Per-IP stream limit, or null for default.")
+        .default(null),
+    })
+    .optional(),
   name: z
     .string()
     .describe(
@@ -62,13 +105,6 @@ export const UpdateApiKeyToolScheme = z.object({
         )
         .optional()
         .default([]),
-      http_rate_limit_per_ip: z
-        .number()
-        .describe(
-          "The http rate limit per ip. If not provided, the default 2,000,000 Compute Units per 5 minutes rate limit will be used."
-        )
-        .optional()
-        .default(2000000),
       web_app_urls: z
         .array(z.string())
         .describe(
@@ -76,6 +112,24 @@ export const UpdateApiKeyToolScheme = z.object({
         )
         .optional()
         .default([]),
+      per_ip_limit_rules: z
+        .array(HttpLimitRuleSchema)
+        .describe(
+          "Per-IP rate limit rules. Leave empty for default rate limits."
+        )
+        .optional()
+        .default([]),
+      enforce_origin: z
+        .boolean()
+        .describe("Whether to enforce origin checking for requests.")
+        .optional()
+        .default(false),
+      per_ip_stream_limit: z
+        .number()
+        .nullable()
+        .describe("Per-IP stream limit, or null for default.")
+        .optional()
+        .default(null),
     })
     .optional(),
   new_api_key_name: z


### PR DESCRIPTION
- Rename AptosBuild service to Geomi
- Rename tools folder from aptos_build to geomi
- Update all tool names (e.g., get_aptos_build_applications -> get_geomi_applications)
- Update URLs from build.aptoslabs.com to geomi.dev
- Update config key from aptos_build to geomi
- Update all documentation and descriptions
- Upgrade @aptos-labs/api-gateway-admin-api-client from v2 to v4
- Update CreateApiKeyFrontendArgs schema for v4 API compatibility
  - Remove http_rate_limit_per_ip
  - Add per_ip_limit_rules, enforce_origin, per_ip_stream_limit
- Add toApiFrontendArgs helper for type conversion