### PR TITLE
Add CI workflow with SHA-pinned GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm run test -- --passWithNoTests
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a GitHub Actions CI workflow for this repository. All third-party actions are pinned to commit SHAs (not floating tags) for supply chain security.

## Workflow

Runs on pushes to `main` and on all pull requests:

1. **Install** — `npm ci` with Node.js 22 (from `.nvmrc`) and npm cache
2. **Test** — `vitest run --passWithNoTests` (no test files exist yet)
3. **Build** — `npm run build` (TypeScript compile + resource copy)

## Pinned actions

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v7.0.0 (2026-06-18) | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` |
| `actions/setup-node` | v6.4.0 (2026-04-20) | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` |

Both releases are more than 3 days old as of 2026-07-02.

## Notes

- `npm run lint` is not included yet because the current lint script fails on main (missing `jiti` dependency for `eslint.config.ts`, Prettier formatting drift, and ESLint rule violations). A follow-up can add lint once those are resolved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f22b4-1330-7cd0-a685-2071c3cbbdf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f22b4-1330-7cd0-a685-2071c3cbbdf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

